### PR TITLE
Jolokia 1.6.2 doesn't work in jetty 9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM jetty:9.4.18-alpine
 
-ENV JOLOKIA_VERSION=1.5.0 JOLOKIA_JSR160_PROXY_ENABLED=TRUE
-RUN wget http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-war/${JOLOKIA_VERSION}/jolokia-war-${JOLOKIA_VERSION}.war -O /var/lib/jetty/webapps/jolokia.war
-
+ENV JOLOKIA_VERSION=1.6.2 JOLOKIA_JSR160_PROXY_ENABLED=TRUE
+RUN wget http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-war-unsecured/${JOLOKIA_VERSION}/jolokia-war-unsecured-${JOLOKIA_VERSION}.war -O /var/lib/jetty/webapps/jolokia.war
 EXPOSE 8080/tcp
 
 CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM jetty:9.4.18-alpine
 
-ENV JOLOKIA_VERSION=1.6.2 JOLOKIA_JSR160_PROXY_ENABLED=TRUE
+ENV JOLOKIA_VERSION=1.5.0 JOLOKIA_JSR160_PROXY_ENABLED=TRUE
 RUN wget http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-war/${JOLOKIA_VERSION}/jolokia-war-${JOLOKIA_VERSION}.war -O /var/lib/jetty/webapps/jolokia.war
 
 EXPOSE 8080/tcp


### PR DESCRIPTION
Sorry, some problems appears when you try to run jolokia 1.6.2 in jetty. 9.4.9 or 9.4.18.

https://github.com/rhuss/jolokia/issues/406